### PR TITLE
Support derivation for generic types

### DIFF
--- a/modules/core/src/test/scala/io/github/irevive/union/derivation/ComplexTypeDerivationSuite.scala
+++ b/modules/core/src/test/scala/io/github/irevive/union/derivation/ComplexTypeDerivationSuite.scala
@@ -1,0 +1,54 @@
+package io.github.irevive.union.derivation
+
+class GenericTypeDerivationSuite extends munit.FunSuite {
+
+  import GenericTypeDerivationSuite.*
+
+  test("derive Typeclass for a simple union type") {
+    type UnionType = Int | String
+    val unionTypeGiven: Typeclass[UnionType] = UnionDerivation.derive[Typeclass, UnionType]
+
+    assertEquals(unionTypeGiven.magic(42), "42")
+    assertEquals(unionTypeGiven.magic("some-string-value"), "some-string-value")
+  }
+
+  test("derive Typeclass for a nested type Int") {
+    type UnionType = GenericType[Int]
+    val unionTypeGiven: Typeclass[UnionType] = summon[Typeclass[UnionType]]
+
+    assertEquals(unionTypeGiven.magic(GenericType(42)), "42-complex")
+
+  }
+  test("derive Typeclass for a nested union type") {
+    type UnionType = Int | String
+    given Typeclass[UnionType]                       = UnionDerivation.derive[Typeclass, UnionType]
+    val typeclass: Typeclass[GenericType[UnionType]] = summon[Typeclass[GenericType[UnionType]]]
+
+    assertEquals(typeclass.magic(GenericType(42)), "42-complex")
+    assertEquals(typeclass.magic(GenericType("some-string-value")), "some-string-value-complex")
+  }
+
+  test("derive Typeclass for a union of Int and GenericType[String]") {
+    type UnionType = Int | GenericType[String]
+    val typeclass: Typeclass[UnionType] = UnionDerivation.derive[Typeclass, UnionType]
+
+    assertEquals(typeclass.magic(42), "42")
+    assertEquals(typeclass.magic(GenericType("some-string-value")), "some-string-value-complex")
+  }
+
+}
+
+object GenericTypeDerivationSuite {
+
+  trait Typeclass[A] {
+    def magic(a: A): String
+  }
+
+  given Typeclass[Int]    = _.toString
+  given Typeclass[String] = identity(_)
+
+  case class GenericType[A: Typeclass](value: A)
+  given [A: Typeclass]: Typeclass[GenericType[A]] =
+    a => summon[Typeclass[A]].magic(a.value) + "-complex"
+
+}

--- a/modules/core/src/test/scala/io/github/irevive/union/derivation/GenericTypeDerivationSuite.scala
+++ b/modules/core/src/test/scala/io/github/irevive/union/derivation/GenericTypeDerivationSuite.scala
@@ -16,7 +16,7 @@ class GenericTypeDerivationSuite extends munit.FunSuite {
     type UnionType = GenericType[Int]
     val unionTypeGiven: Typeclass[UnionType] = summon[Typeclass[UnionType]]
 
-    assertEquals(unionTypeGiven.magic(GenericType(42)), "42-complex")
+    assertEquals(unionTypeGiven.magic(GenericType(42)), "42-generic")
 
   }
   test("derive Typeclass for a nested union type") {
@@ -24,8 +24,8 @@ class GenericTypeDerivationSuite extends munit.FunSuite {
     given Typeclass[UnionType]                       = UnionDerivation.derive[Typeclass, UnionType]
     val typeclass: Typeclass[GenericType[UnionType]] = summon[Typeclass[GenericType[UnionType]]]
 
-    assertEquals(typeclass.magic(GenericType(42)), "42-complex")
-    assertEquals(typeclass.magic(GenericType("some-string-value")), "some-string-value-complex")
+    assertEquals(typeclass.magic(GenericType(42)), "42-generic")
+    assertEquals(typeclass.magic(GenericType("some-string-value")), "some-string-value-generic")
   }
 
   test("derive Typeclass for a union of Int and GenericType[String]") {
@@ -33,7 +33,7 @@ class GenericTypeDerivationSuite extends munit.FunSuite {
     val typeclass: Typeclass[UnionType] = UnionDerivation.derive[Typeclass, UnionType]
 
     assertEquals(typeclass.magic(42), "42")
-    assertEquals(typeclass.magic(GenericType("some-string-value")), "some-string-value-complex")
+    assertEquals(typeclass.magic(GenericType("some-string-value")), "some-string-value-generic")
   }
 
 }
@@ -49,6 +49,6 @@ object GenericTypeDerivationSuite {
 
   case class GenericType[A: Typeclass](value: A)
   given [A: Typeclass]: Typeclass[GenericType[A]] =
-    a => summon[Typeclass[A]].magic(a.value) + "-complex"
+    a => summon[Typeclass[A]].magic(a.value) + "-generic"
 
 }


### PR DESCRIPTION
Due to the mapping to `typeSymbol` in `UnionDerivation` macro logic the parametric type got erased, leading to failing derivation for unions like `Int | MyType[String]`. This PR fixes that by propagating more information down the line for implicit resolution,