### PR TITLE
Use `=:=` to compare `TypeRepr`s

### DIFF
--- a/modules/core/src/main/scala/io/github/irevive/union/derivation/UnionDerivation.scala
+++ b/modules/core/src/main/scala/io/github/irevive/union/derivation/UnionDerivation.scala
@@ -1,5 +1,6 @@
 package io.github.irevive.union.derivation
 
+import scala.language.strictEquality
 import scala.quoted.*
 
 object UnionDerivation {
@@ -63,7 +64,7 @@ object UnionDerivation {
       method.paramss match {
         case TermParamClause(params) :: Nil =>
           val all = params.map { param =>
-            MethodParam(param.name, param.tpt.tpe, param.tpt.tpe == paramType)
+            MethodParam(param.name, param.tpt.tpe, param.tpt.tpe =:= paramType)
           }
 
           val typed = all.filter(_.isPoly)


### PR DESCRIPTION
Closes #176.

Some types are represented differently between recompilations. I assume the compiler uses a cached version. 
Comparing types via universal equality `==` is a bad idea 😅. 
